### PR TITLE
systemd networking

### DIFF
--- a/.config.yaml
+++ b/.config.yaml
@@ -49,8 +49,7 @@ local_conf_header:
     UBOOT_MACHINE:raspberrypi5 = "rpi_arm64_defconfig"
     SERIAL_CONSOLES = "115200;ttyAMA0"
     EXTRA_IMAGE_FEATURES += "debug-tweaks"
-    IMAGE_INSTALL:append = " openssh openssh-sftp-server avahi-daemon dhcpcd libgcc vim htop swupdate swupdate-www etc-overlay "
-
+    IMAGE_INSTALL:append = " openssh openssh-sftp-server avahi-daemon libgcc vim htop swupdate swupdate-www etc-overlay "
     DISTRO_FEATURES:append = " systemd usrmerge"
     VIRTUAL-RUNTIME_init_manager = "systemd"
     IMAGE_FSTYPES:append = " ext4.gz wic.bz2"

--- a/.config.yaml
+++ b/.config.yaml
@@ -54,3 +54,4 @@ local_conf_header:
     VIRTUAL-RUNTIME_init_manager = "systemd"
     IMAGE_FSTYPES:append = " ext4.gz wic.bz2"
     WKS_FILE = "ts-raspberrypi.wks"
+    PACKAGECONFIG:pn-openssh = "systemd-sshd-service-mode"

--- a/meta-berge/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-berge/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,0 +1,7 @@
+# meta-berge/recipes-connectivity/openssh/openssh_%.bbappend
+
+PACKAGECONFIG:remove = "systemd-sshd-socket-mode"
+PACKAGECONFIG:append = " systemd-sshd-service-mode"
+
+SYSTEMD_SERVICE:openssh-sshd = "sshd.service"
+SYSTEMD_AUTO_ENABLE:openssh-sshd = "enable"

--- a/meta-berge/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-berge/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,7 +1,0 @@
-# meta-berge/recipes-connectivity/openssh/openssh_%.bbappend
-
-PACKAGECONFIG:remove = "systemd-sshd-socket-mode"
-PACKAGECONFIG:append = " systemd-sshd-service-mode"
-
-SYSTEMD_SERVICE:openssh-sshd = "sshd.service"
-SYSTEMD_AUTO_ENABLE:openssh-sshd = "enable"

--- a/meta-berge/recipes-core/systemd/files/38-rpi5-dhcp.network
+++ b/meta-berge/recipes-core/systemd/files/38-rpi5-dhcp.network
@@ -1,0 +1,16 @@
+[Match]
+Type=ether
+Name=!veth*
+KernelCommandLine=!nfsroot
+KernelCommandLine=!ip
+
+[Network]
+DHCP=yes
+LinkLocalAddressing=yes
+IPv6AcceptRA=no
+MulticastDNS=yes
+
+[DHCP]
+UseMTU=yes
+RouteMetric=10
+ClientIdentifier=mac

--- a/meta-berge/recipes-core/systemd/files/39-rpi5-static.network
+++ b/meta-berge/recipes-core/systemd/files/39-rpi5-static.network
@@ -1,0 +1,8 @@
+[Match]
+Name=eth0
+ 
+[Network]
+Address=192.168.1.2/16
+Gateway=192.168.1.1
+DNS=192.168.1.1
+IPv6AcceptRA=no

--- a/meta-berge/recipes-core/systemd/systemd-conf_%.bbappend
+++ b/meta-berge/recipes-core/systemd/systemd-conf_%.bbappend
@@ -1,0 +1,17 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+THIS_MACHINE_NETWORK_FILE_1 ??= "38-rpi5-dhcp.network"
+THIS_MACHINE_NETWORK_FILE_2 ??= "39-rpi5-static.network"
+
+SRC_URI:append = " \
+    file://${THIS_MACHINE_NETWORK_FILE_1} \
+    file://${THIS_MACHINE_NETWORK_FILE_2} \
+"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/systemd/network
+    install -m 0644 ${WORKDIR}/${THIS_MACHINE_NETWORK_FILE_1} ${D}${sysconfdir}/systemd/network/${THIS_MACHINE_NETWORK_FILE_1}
+    install -m 0644 ${WORKDIR}/${THIS_MACHINE_NETWORK_FILE_2} ${D}${sysconfdir}/systemd/network/${THIS_MACHINE_NETWORK_FILE_2}
+}
+
+FILES:${PN}:append = " ${sysconfdir}/systemd/network/"

--- a/meta-berge/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-berge/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,2 @@
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+SYSTEMD_SERVICE:${PN} = "systemd-networkd.service"

--- a/meta-berge/recipes-support/swupdate/swupdate/rpi/swupdate-ab.sh
+++ b/meta-berge/recipes-support/swupdate/swupdate/rpi/swupdate-ab.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+rootfs=$(swupdate -g)
+if [ "$rootfs" = "/dev/mmcblk0p2" ]; then
+    selection="-e stable,copy2"
+else
+    selection="-e stable,copy1"
+fi
+
+if [ -e /media/etc/swupdate.cfg ]; then
+    CFGFILE="/media/etc/swupdate.cfg"
+else
+    CFGFILE="/etc/swupdate.cfg"
+fi
+
+# Web UI only — no Suricatta
+exec /usr/bin/swupdate -v -H raspberrypi5:1.0 $selection -p 'sync && reboot -f' -f "$CFGFILE" -w "-r /www -p 8080"

--- a/meta-berge/recipes-support/swupdate/swupdate/rpi/swupdate.service
+++ b/meta-berge/recipes-support/swupdate/swupdate/rpi/swupdate.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=SWUpdate daemon (A/B slot logic)
+Documentation=https://sbabic.github.io/swupdate/
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/swupdate-ab.sh
+KillMode=mixed
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-berge/recipes-support/swupdate/swupdate_%.bbappend
+++ b/meta-berge/recipes-support/swupdate/swupdate_%.bbappend
@@ -2,9 +2,17 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append:raspberrypi5 = " \
     file://rpi/swupdate.cfg \
+    file://rpi/swupdate-ab.sh \
+    file://rpi/swupdate.service \
 "
 
 do_install:append:raspberrypi5() {
     install -d ${D}${sysconfdir}
     install -m 0644 ${WORKDIR}/rpi/swupdate.cfg ${D}${sysconfdir}/swupdate.cfg
+
+    install -m 0755 ${WORKDIR}/rpi/swupdate-ab.sh ${D}${bindir}/swupdate-ab.sh
+    install -m 0644 ${WORKDIR}/rpi/swupdate.service ${D}${systemd_system_unitdir}/swupdate.service
 }
+
+SYSTEMD_SERVICE:${PN} = "swupdate.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"


### PR DESCRIPTION
This PR replaces legacy or unreliable defaults with a cleaner systemd-based setup for networking, SWUpdate, and SSH — ensuring all key services start reliably at boot.